### PR TITLE
MetaKeyPattern: rename fields + HTML fix

### DIFF
--- a/includes/classes/Feature/MetaKeyPattern.php
+++ b/includes/classes/Feature/MetaKeyPattern.php
@@ -28,8 +28,8 @@ class MetaKeyPattern extends \ElasticPress\Feature {
 
 		$this->requires_install_reindex = false;
 		$this->default_settings         = [
-			'feature_meta_key_allow_pattern_setting' => '',
-			'feature_meta_key_deny_pattern_setting'  => '',
+			'meta_key_allow_pattern' => '',
+			'meta_key_deny_pattern'  => '',
 		];
 
 		parent::__construct();
@@ -60,17 +60,18 @@ class MetaKeyPattern extends \ElasticPress\Feature {
 	public function setup() {
 		$settings = $this->get_settings();
 
-		if ( $settings['active'] ) {
-			add_filter( 'ep_prepare_meta_data', array( $this, 'exclude_meta_key_patterns' ), 5, 2 );
-			add_filter( 'ep_prepare_meta_data', array( $this, 'include_meta_key_patterns' ), 10, 2 );
-			add_filter(
-				'ep_weighting_configuration_for_search',
-				array( $this, 'update_weighting_configuration_for_search' )
-			);
-			add_action( 'update_postmeta', array( $this, 'delete_transient_on_meta_update' ), 10, 3 );
-			add_action( 'wp_ajax_epl_meta_key_pattern_after_save', array( $this, 'after_save_settings' ) );
+		if ( ! $settings['active'] ) {
+			return;
 		}
 
+		add_filter( 'ep_prepare_meta_data', array( $this, 'exclude_meta_key_patterns' ), 5, 2 );
+		add_filter( 'ep_prepare_meta_data', array( $this, 'include_meta_key_patterns' ), 10, 2 );
+		add_filter(
+			'ep_weighting_configuration_for_search',
+			array( $this, 'update_weighting_configuration_for_search' )
+		);
+		add_action( 'update_postmeta', array( $this, 'delete_transient_on_meta_update' ), 10, 3 );
+		add_action( 'wp_ajax_epl_meta_key_pattern_after_save', array( $this, 'after_save_settings' ) );
 	}
 
 	/**
@@ -88,17 +89,17 @@ class MetaKeyPattern extends \ElasticPress\Feature {
 		?>
 		<div class="field js-toggle-feature" data-feature="<?php echo esc_attr( $this->slug ); ?>">
 			<div class="field-name status">
-				<label for="feature_my_feature_setting">
+				<label for="meta_key_allow_pattern">
 					<?php esc_html_e( 'Allow patterns', 'elasticpress-labs' ); ?>
 				</label>
 			</div>
 			<div class="input-wrap">
 				<textarea
-					class="setting-field"
-					id="feature_meta_key_allow_pattern_setting"
+					class="setting-field large-text code"
+					id="meta_key_allow_pattern"
 					rows="4"
-					data-field-name="feature_meta_key_allow_pattern_setting"
-				><?php echo empty( $settings['feature_meta_key_allow_pattern_setting'] ) ? '' : esc_attr( $settings['feature_meta_key_allow_pattern_setting'] ); ?></textarea>
+					name="settings[meta_key_allow_pattern]"
+				><?php echo empty( $settings['meta_key_allow_pattern'] ) ? '' : esc_textarea( $settings['meta_key_allow_pattern'] ); ?></textarea>
 				<p class="field-description">
 					<?php esc_html_e( 'Separate multiple regular expressions with line breaks.', 'elasticpress-labs' ); ?>
 					<?php esc_html_e( 'Include the weight of the pattern adding a pipe (|) followed by a number. Example: /^[a-z]/|5', 'elasticpress-labs' ); ?>
@@ -108,17 +109,17 @@ class MetaKeyPattern extends \ElasticPress\Feature {
 
 		<div class="field js-toggle-feature" data-feature="<?php echo esc_attr( $this->slug ); ?>">
 			<div class="field-name status">
-				<label for="feature_my_feature_setting">
+				<label for="meta_key_deny_pattern">
 					<?php esc_html_e( 'Deny patterns', 'elasticpress-labs' ); ?>
 				</label>
 			</div>
 			<div class="input-wrap">
 				<textarea
-					class="setting-field"
-					id="feature_meta_key_deny_pattern_setting"
+					class="setting-field large-text code"
+					id="meta_key_deny_pattern"
 					rows="4"
-					data-field-name="feature_meta_key_deny_pattern_setting"
-				><?php echo empty( $settings['feature_meta_key_deny_pattern_setting'] ) ? '' : esc_attr( $settings['feature_meta_key_deny_pattern_setting'] ); ?></textarea>
+					name="settings[meta_key_deny_pattern]"
+				><?php echo empty( $settings['meta_key_deny_pattern'] ) ? '' : esc_textarea( $settings['meta_key_deny_pattern'] ); ?></textarea>
 				<p class="field-description">
 					<?php esc_html_e( 'Separate multiple regular expressions with line breaks.', 'elasticpress-labs' ); ?>
 				</p>
@@ -198,7 +199,7 @@ class MetaKeyPattern extends \ElasticPress\Feature {
 	private function get_allowed_meta_key_patterns() {
 		$settings = $this->get_settings();
 
-		$allowed_patterns = preg_split( "/\r\n|\n|\r/", $settings['feature_meta_key_allow_pattern_setting'] );
+		$allowed_patterns = preg_split( "/\r\n|\n|\r/", $settings['meta_key_allow_pattern'] );
 
 		$allowed_patterns = array_map(
 			function( $pattern ) {
@@ -241,7 +242,7 @@ class MetaKeyPattern extends \ElasticPress\Feature {
 	private function get_denied_meta_key_patterns() {
 		$settings = $this->get_settings();
 
-		$denied_patterns = preg_split( "/\r\n|\n|\r/", $settings['feature_meta_key_deny_pattern_setting'] );
+		$denied_patterns = preg_split( "/\r\n|\n|\r/", $settings['meta_key_deny_pattern'] );
 
 		return $denied_patterns;
 	}
@@ -343,7 +344,7 @@ class MetaKeyPattern extends \ElasticPress\Feature {
 	private function get_weight_pattern( $pattern ) {
 		$settings = $this->get_settings();
 
-		$save_patterns = preg_split( "/\r\n|\n|\r/", $settings['feature_meta_key_allow_pattern_setting'] );
+		$save_patterns = preg_split( "/\r\n|\n|\r/", $settings['meta_key_allow_pattern'] );
 
 		foreach ( $save_patterns as $save_pattern ) {
 			if ( $pattern === $save_pattern ) {
@@ -434,10 +435,10 @@ class MetaKeyPattern extends \ElasticPress\Feature {
 		$last_save = get_site_option( 'epl_last_save_meta_key_patterns' );
 		$last_sync = get_site_option( 'ep_last_sync' );
 
+		$status = new ElasticPress\FeatureRequirementsStatus( 0 );
 		if ( ! isset( $_GET['do_sync'] ) && $last_save > $last_sync ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$status = new ElasticPress\FeatureRequirementsStatus( 1 );
-
 			$status->message = [];
+			$status->code    = 1;
 
 			if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 				$url = admin_url( 'network/admin.php?page=elasticpress&do_sync' );
@@ -445,10 +446,13 @@ class MetaKeyPattern extends \ElasticPress\Feature {
 				$url = admin_url( 'admin.php?page=elasticpress&do_sync' );
 			}
 
-			$status->message[] = sprintf( __( 'You will need to <a href="%1$s">run a sync</a> to update your index.', 'elasticpress-labs' ), esc_url( $url ) );
-
-			return $status;
+			$status->message[] = sprintf(
+				/* translators: Sync Page URL */
+				__( 'You will need to <a href="%1$s">run a sync</a> to update your index.', 'elasticpress-labs' ),
+				esc_url( $url )
+			);
 		}
+		return $status;
 	}
 
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Related to #32

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Meta Key Pattern: settings fields renamed and HTML fix 


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
