### PR TITLE
Avoid "Cannot declare class ElasticPressLabs" error

### DIFF
--- a/includes/classes/Feature/ElasticPressLabs.php
+++ b/includes/classes/Feature/ElasticPressLabs.php
@@ -179,7 +179,7 @@ class ElasticPressLabs extends \ElasticPress\Feature {
 		);
 
 		foreach ( $features_files as $filename ) {
-			require ELASTICPRESS_LABS_INC . 'classes/Feature/' . basename( $filename );
+			require_once ELASTICPRESS_LABS_INC . 'classes/Feature/' . basename( $filename );
 
 			$class_name = 'ElasticPressLabs\Feature\\' . basename( $filename, '.php' );
 


### PR DESCRIPTION
### Description of the Change
Depending on if ElasticPressLabs or ElasticPress plugin is loaded first, there's a situation where `core.php`'s `maybe_load_features` function and ElasticPress' `Features.php`'s `setup_features` both run  - which causes the class to attempt two loads.

Moving the `register_subfeatures` to `require_once` prevents this conflict, while keeping the other feature loading functionality in place.

### How to test the Change
Either change the order the plugins have been installed into your repo, or manually alter with WordPress' `activated_plugin` action. The behavior can be experienced if you toggle the load order between ElasticPress and ElasticPressLabs.

### Changelog Entry
> Fixed - Ensure feature classes are only loaded once.


### Credits
Props @ecaron


### Checklist:
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [X] All new and existing tests pass.
