### PR TITLE
Hide Subscription feature if plugin not activated

### DIFF
--- a/includes/classes/Feature/ElasticPressLabs.php
+++ b/includes/classes/Feature/ElasticPressLabs.php
@@ -81,6 +81,10 @@ class ElasticPressLabs extends \ElasticPress\Feature {
 		$settings = wp_parse_args( $settings, $this->default_settings );
 
 		foreach ( $this->subfeatures as $subfeature ) {
+			if ( ! $subfeature->is_visible ) {
+				continue;
+			}
+
 			$this->subfeature_field(
 				$subfeature->slug,
 				$subfeature->title,
@@ -192,6 +196,7 @@ class ElasticPressLabs extends \ElasticPress\Feature {
 						'slug'        => $subfeature->slug,
 						'title'       => $subfeature->title,
 						'description' => $description,
+						'is_visible'  => $subfeature->is_visible(),
 					)
 				);
 

--- a/includes/classes/Feature/ElasticPressLabs.php
+++ b/includes/classes/Feature/ElasticPressLabs.php
@@ -196,7 +196,7 @@ class ElasticPressLabs extends \ElasticPress\Feature {
 						'slug'         => $subfeature->slug,
 						'title'        => $subfeature->title,
 						'description'  => $description,
-						'is_available' => $subfeature->is_available(),
+						'is_available' => method_exists( $subfeature, 'is_available' ) ? $subfeature->is_available() : true,
 						'is_active'    => $subfeature->is_active(),
 					)
 				);

--- a/includes/classes/Feature/ElasticPressLabs.php
+++ b/includes/classes/Feature/ElasticPressLabs.php
@@ -81,7 +81,7 @@ class ElasticPressLabs extends \ElasticPress\Feature {
 		$settings = wp_parse_args( $settings, $this->default_settings );
 
 		foreach ( $this->subfeatures as $subfeature ) {
-			if ( ! $subfeature->is_visible ) {
+			if ( ! $subfeature->is_available && ! $subfeature->is_active ) {
 				continue;
 			}
 
@@ -193,10 +193,11 @@ class ElasticPressLabs extends \ElasticPress\Feature {
 
 				$this->add_to_subfeatures(
 					array(
-						'slug'        => $subfeature->slug,
-						'title'       => $subfeature->title,
-						'description' => $description,
-						'is_visible'  => $subfeature->is_visible(),
+						'slug'         => $subfeature->slug,
+						'title'        => $subfeature->title,
+						'description'  => $description,
+						'is_available' => $subfeature->is_available(),
+						'is_active'    => $subfeature->is_active(),
 					)
 				);
 

--- a/includes/classes/Feature/WooCommerceSubscriptionSearch.php
+++ b/includes/classes/Feature/WooCommerceSubscriptionSearch.php
@@ -136,7 +136,11 @@ class WooCommerceSubscriptionSearch extends \ElasticPress\Feature {
 
 		$woocommerce_feature       = \ElasticPress\Features::factory()->get_registered_feature( 'woocommerce' );
 		$protected_content_feature = \ElasticPress\Features::factory()->get_registered_feature( 'protected_content' );
-		if ( ! $woocommerce_feature->is_active() || ! $protected_content_feature->is_active() ) {
+
+		if ( ! $this->is_visible ) {
+			$status->code    = 2;
+			$status->message = esc_html__( 'This feature requires the WooCommerce Subscriptions plugin to be activated.', 'elasticpress-labs' );
+		} elseif ( ! $woocommerce_feature->is_active() || ! $protected_content_feature->is_active() ) {
 			$status->code    = 2;
 			$status->message = esc_html__( 'This feature requires the WooCommerce and Protected Content features to be enabled.', 'elasticpress-labs' );
 		} else {
@@ -152,7 +156,7 @@ class WooCommerceSubscriptionSearch extends \ElasticPress\Feature {
 	 * @return void
 	 */
 	public function maybe_hide_feature() {
-		if ( ! class_exists( '\WooCommerce' ) || ! class_exists( '\WC_Subscriptions' ) ) {
+		if ( ! class_exists( '\WC_Subscriptions' ) ) {
 			$this->is_visible = false;
 		}
 	}

--- a/includes/classes/Feature/WooCommerceSubscriptionSearch.php
+++ b/includes/classes/Feature/WooCommerceSubscriptionSearch.php
@@ -34,6 +34,8 @@ class WooCommerceSubscriptionSearch extends \ElasticPress\Feature {
 
 		$this->requires_install_reindex = true;
 
+		$this->maybe_hide_feature();
+
 		parent::__construct();
 	}
 
@@ -142,5 +144,16 @@ class WooCommerceSubscriptionSearch extends \ElasticPress\Feature {
 		}
 
 		return $status;
+	}
+
+	/**
+	 * Hide feature if WooCommerce Subscriptions is not active.
+	 *
+	 * @return void
+	 */
+	public function maybe_hide_feature() {
+		if ( ! class_exists( '\WooCommerce' ) || ! class_exists( '\WC_Subscriptions' ) ) {
+			$this->is_visible = false;
+		}
 	}
 }

--- a/includes/classes/Feature/WooCommerceSubscriptionSearch.php
+++ b/includes/classes/Feature/WooCommerceSubscriptionSearch.php
@@ -34,8 +34,6 @@ class WooCommerceSubscriptionSearch extends \ElasticPress\Feature {
 
 		$this->requires_install_reindex = true;
 
-		$this->maybe_hide_feature();
-
 		parent::__construct();
 	}
 
@@ -137,7 +135,7 @@ class WooCommerceSubscriptionSearch extends \ElasticPress\Feature {
 		$woocommerce_feature       = \ElasticPress\Features::factory()->get_registered_feature( 'woocommerce' );
 		$protected_content_feature = \ElasticPress\Features::factory()->get_registered_feature( 'protected_content' );
 
-		if ( ! $this->is_visible ) {
+		if ( ! $this->is_subscription_plugin_activated() ) {
 			$status->code    = 2;
 			$status->message = esc_html__( 'This feature requires the WooCommerce Subscriptions plugin to be activated.', 'elasticpress-labs' );
 		} elseif ( ! $woocommerce_feature->is_active() || ! $protected_content_feature->is_active() ) {
@@ -151,13 +149,11 @@ class WooCommerceSubscriptionSearch extends \ElasticPress\Feature {
 	}
 
 	/**
-	 * Hide feature if WooCommerce Subscriptions is not active.
+	 * Check if WooCommerce Subscriptions plugin is activated.
 	 *
-	 * @return void
+	 * @return bool
 	 */
-	public function maybe_hide_feature() {
-		if ( ! class_exists( '\WC_Subscriptions' ) ) {
-			$this->is_visible = false;
-		}
+	public function is_subscription_plugin_activated() : bool {
+		return is_plugin_active( 'woocommerce-subscriptions/woocommerce-subscriptions.php' ) && class_exists( '\WC_Subscriptions' );
 	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR hides the feature if the required plugin is not activated. Required PR opened in the main plugin https://github.com/10up/ElasticPress/pull/3356

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #55 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Hide the Subscription and Co Author feature if the required plugin is not activated 


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
