### PR TITLE
Change the default operator

### DIFF
--- a/includes/classes/Feature/BooleanSearchOperators.php
+++ b/includes/classes/Feature/BooleanSearchOperators.php
@@ -145,7 +145,7 @@ class BooleanSearchOperators extends Feature {
 				 *
 				 * @return {string} New operator
 				 */
-				'default_operator' => \apply_filters( 'ep_labs_boolean_operators_default', 'OR', $query_vars, $search_text, $search_fields, $query ),
+				'default_operator' => \apply_filters( 'ep_labs_boolean_operators_default', 'AND', $query_vars, $search_text, $search_fields, $query ),
 
 				/**
 				 * Filter allowed boolean operators.


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Changing the default operator to resolve the issue with Boolean operators
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #66 

### How to test the Change
1. Create posts with the title "Museum Art", Museum and Art
2. Search for "Museum Not Art"
3. The result should only have the post with Museum but not Museum Art and Art
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Boolean Operator (Not) is not giving the expected result

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @MARQAS

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
