### PR TITLE
Bumped `actions/upload-artifact` from v3 to v4

### DIFF
--- a/.github/workflows/build-with-vendor.yml
+++ b/.github/workflows/build-with-vendor.yml
@@ -37,7 +37,7 @@ jobs:
       run: npm run build:zip
 
     - name: Make artifacts available
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: elasticpress-labs
         retention-days: 2


### PR DESCRIPTION
### Description of the Change
The v3 version of the artifact actions is deprecated, and starting November 30, 2024, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact). More info can be found [here](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

This PR updates `actions/upload-artifact` from v3 to v4.

### How to test the Change
Verify that workflows using this GitHub action work fine.

### Changelog Entry
> Changed - Bumped `actions/upload-artifact` from v3 to v4


### Credits
Props @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
