### PR TITLE
Fix: User correct textdomain and remove unused variable

### DIFF
--- a/includes/classes/Feature/Users.php
+++ b/includes/classes/Feature/Users.php
@@ -22,11 +22,11 @@ class Users extends Feature {
 	public function __construct() {
 		$this->slug = 'users';
 
-		$this->title = esc_html__( 'Users', 'elasticpress' );
+		$this->title = esc_html__( 'Users', 'elasticpress-labs' );
 
-		$this->summary = __( 'Improve user search relevancy and query performance.', 'elasticpress' );
+		$this->summary = __( 'Improve user search relevancy and query performance.', 'elasticpress-labs' );
 
-		$this->docs_url = __( 'https://elasticpress.zendesk.com/hc/en-us/articles/360050447492-Configuring-ElasticPress-via-the-Plugin-Dashboard#users', 'elasticpress' );
+		$this->docs_url = __( 'https://elasticpress.zendesk.com/hc/en-us/articles/360050447492-Configuring-ElasticPress-via-the-Plugin-Dashboard#users', 'elasticpress-labs' );
 
 		$this->requires_install_reindex = true;
 
@@ -58,8 +58,8 @@ class Users extends Feature {
 	 */
 	public function output_feature_box_long() {
 		?>
-		<p><?php esc_html_e( 'This feature will empower your website to overcome traditional WordPress user search and query limitations that can present themselves at scale.', 'elasticpress' ); ?></p>
-		<p><?php esc_html_e( 'Be aware that storing user data may bound you to certain legal obligations depending on your local government regulations.', 'elasticpress' ); ?></p>
+		<p><?php esc_html_e( 'This feature will empower your website to overcome traditional WordPress user search and query limitations that can present themselves at scale.', 'elasticpress-labs' ); ?></p>
+		<p><?php esc_html_e( 'Be aware that storing user data may bound you to certain legal obligations depending on your local government regulations.', 'elasticpress-labs' ); ?></p>
 		<?php
 	}
 

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -41,8 +41,8 @@ class User extends Indexable {
 	 */
 	public function __construct() {
 		$this->labels = [
-			'plural'   => esc_html__( 'Users', 'elasticpress' ),
-			'singular' => esc_html__( 'User', 'elasticpress' ),
+			'plural'   => esc_html__( 'Users', 'elasticpress-labs' ),
+			'singular' => esc_html__( 'User', 'elasticpress-labs' ),
 		];
 	}
 
@@ -64,8 +64,6 @@ class User extends Indexable {
 	 * @return array
 	 */
 	public function format_args( $query_vars, $query ) {
-		global $wpdb;
-
 		/**
 		 * Handle `number` query var
 		 */


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR adds the correct text-domain for the user's feature and remove unused variable

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Use correct textdomain. 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
