### PR TITLE
Add filters in User's query_db method

### DIFF
--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -677,6 +677,7 @@ class User extends Indexable {
 			'objects'       => $objects,
 			'total_objects' => ( 0 === count( $objects ) ) ? 0 : (int) $wpdb->get_var( 'SELECT FOUND_ROWS()' ),
 		];
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
 	}
 
 	/**

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -631,6 +631,20 @@ class User extends Indexable {
 			$args['order'] = 'desc';
 		}
 
+		/**
+		 * Filter to short-circuit user DB query.
+		 *
+		 * @hook ep_user_pre_query_db_results
+		 * @param {null|array} $results Return null to run the default query, or an array with results to short-circuit
+		 * @param {array} $args Query arguments
+		 * @since 2.5.0
+		 * @return {null|array} Query results or null
+		 */
+		$results = apply_filters( 'ep_user_pre_query_db_results', null, $args );
+		if ( null !== $results ) {
+			return $results;
+		}
+
 		$orderby_args = sanitize_sql_orderby( "{$args['orderby']} {$args['order']}" );
 		$orderby      = $orderby_args ? sprintf( 'ORDER BY %s', $orderby_args ) : '';
 
@@ -639,18 +653,30 @@ class User extends Indexable {
 		 * way to do that.
 		 */
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
-		$objects = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT SQL_CALC_FOUND_ROWS ID FROM {$wpdb->users} {$orderby} LIMIT %d, %d",
-				(int) $args['offset'],
-				(int) $args['number']
-			)
+		$sql = $wpdb->prepare(
+			"SELECT SQL_CALC_FOUND_ROWS ID FROM {$wpdb->users} {$orderby} LIMIT %d, %d",
+			(int) $args['offset'],
+			(int) $args['number']
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
+
+		/**
+		 * Filter user indexable DB query SQL.
+		 *
+		 * @hook ep_user_query_db_sql
+		 * @param {string} $sql The SQL query to be executed
+		 * @param {array} $args Query arguments
+		 * @since 2.5.0
+		 * @return {string} Modified SQL query
+		 */
+		$sql = apply_filters( 'ep_user_query_db_sql', $sql, $args );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery
+		$objects = $wpdb->get_results( $sql );
 		return [
 			'objects'       => $objects,
 			'total_objects' => ( 0 === count( $objects ) ) ? 0 : (int) $wpdb->get_var( 'SELECT FOUND_ROWS()' ),
 		];
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
 	}
 
 	/**

--- a/tests/phpunit/indexables/TestUser.php
+++ b/tests/phpunit/indexables/TestUser.php
@@ -1598,27 +1598,27 @@ class TestUser extends BaseTestCase {
 	 * @group user
 	 */
 	public function test_ep_user_query_db_sql_filter() {
-			global $wpdb;
+		global $wpdb;
 
-			$user_id = $this->ep_factory->user->create();
+		$user_id = $this->ep_factory->user->create();
 
-			add_filter(
-				'ep_user_query_db_sql',
-				function () use ( $wpdb, $user_id ) {
-						return $wpdb->prepare(
-							"SELECT SQL_CALC_FOUND_ROWS ID FROM {$wpdb->users} WHERE ID = %d",
-							$user_id
-						);
-				},
-				10,
-				2
-			);
+		add_filter(
+			'ep_user_query_db_sql',
+			function () use ( $wpdb, $user_id ) {
+				return $wpdb->prepare(
+					"SELECT SQL_CALC_FOUND_ROWS ID FROM {$wpdb->users} WHERE ID = %d",
+					$user_id
+				);
+			},
+			10,
+			2
+		);
 
-			$user    = new \ElasticPressLabs\Indexable\User\User();
-			$results = $user->query_db( [] );
+		$user    = new \ElasticPressLabs\Indexable\User\User();
+		$results = $user->query_db( [] );
 
-			$this->assertCount( 1, $results['objects'] );
-			$this->assertEquals( $user_id, $results['objects'][0]->ID );
-			$this->assertEquals( 1, $results['total_objects'] );
+		$this->assertCount( 1, $results['objects'] );
+		$this->assertEquals( $user_id, $results['objects'][0]->ID );
+		$this->assertEquals( 1, $results['total_objects'] );
 	}
 }

--- a/tests/phpunit/indexables/TestUser.php
+++ b/tests/phpunit/indexables/TestUser.php
@@ -1556,4 +1556,69 @@ class TestUser extends BaseTestCase {
 		$index_settings = $settings[ $index_name ]['settings'];
 		$this->assertSame( '_arabic_', $index_settings['index.analysis.filter.ep_stop.stopwords'] );
 	}
+
+	/**
+	 * Test ep_user_pre_query_db_results filter to short-circuit the DB query
+	 *
+	 * @since 2.5.0
+	 * @group user
+	 */
+	public function test_ep_user_pre_query_db_results_filter() {
+		$users = $this->createAndIndexUsers();
+
+		$expected_results = [
+			'objects'       => [
+				(object) [ 'ID' => $users[0] ],
+				(object) [ 'ID' => $users[1] ],
+			],
+			'total_objects' => 2,
+		];
+
+		// Add filter to short-circuit the query
+		add_filter(
+			'ep_user_pre_query_db_results',
+			function () use ( $expected_results ) {
+				return $expected_results;
+			}
+		);
+
+		$user    = new \ElasticPressLabs\Indexable\User\User();
+		$results = $user->query_db( [] );
+
+		$this->assertEquals( $expected_results['objects'], $results['objects'] );
+		$this->assertEquals( $expected_results['total_objects'], $results['total_objects'] );
+		$this->assertEquals( $expected_results['objects'][0]->ID, $results['objects'][0]->ID );
+		$this->assertEquals( $expected_results['objects'][1]->ID, $results['objects'][1]->ID );
+	}
+
+	/**
+	 * Test ep_user_query_db_sql filter to modify the SQL query
+	 *
+	 * @since 2.5.0
+	 * @group user
+	 */
+	public function test_ep_user_query_db_sql_filter() {
+			global $wpdb;
+
+			$user_id = $this->ep_factory->user->create();
+
+			add_filter(
+				'ep_user_query_db_sql',
+				function () use ( $wpdb, $user_id ) {
+						return $wpdb->prepare(
+							"SELECT SQL_CALC_FOUND_ROWS ID FROM {$wpdb->users} WHERE ID = %d",
+							$user_id
+						);
+				},
+				10,
+				2
+			);
+
+			$user    = new \ElasticPressLabs\Indexable\User\User();
+			$results = $user->query_db( [] );
+
+			$this->assertCount( 1, $results['objects'] );
+			$this->assertEquals( $user_id, $results['objects'][0]->ID );
+			$this->assertEquals( 1, $results['total_objects'] );
+	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR adds new filters in the User's query_db method.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #117

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New filters in User's query_db method.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @felipeelia @yarovikov

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
