### PR TITLE
Add support for searching posts by Co-Author on the frontend

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
       "name": "10up",
       "email": "info@10up.com",
       "homepage": "https://10up.com",
-			"role": "Developer"
+      "role": "Developer"
     }
   ],
   "require": {
@@ -34,7 +34,8 @@
     "yoast/phpunit-polyfills": "^1.0",
     "wpackagist-plugin/woocommerce": "*",
     "phpcompatibility/phpcompatibility-wp": "*",
-    "phpcompatibility/php-compatibility": "dev-develop as 9.99.99"
+    "phpcompatibility/php-compatibility": "dev-develop as 9.99.99",
+    "wpackagist-plugin/co-authors-plus": "*"
   },
   "scripts": {
     "lint": "phpcs . -s --runtime-set testVersion 7.4-",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc6f16e26ce19864343da23c81461efd",
+    "content-hash": "89f0b91fc96c56b84ff09b7c52d95ac5",
     "packages": [
         {
             "name": "yahnis-elsts/plugin-update-checker",
@@ -3085,6 +3085,24 @@
             "time": "2024-03-25T16:39:00+00:00"
         },
         {
+            "name": "wpackagist-plugin/co-authors-plus",
+            "version": "3.6.5",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/co-authors-plus/",
+                "reference": "tags/3.6.5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/co-authors-plus.3.6.5.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/co-authors-plus/"
+        },
+        {
             "name": "wpackagist-plugin/woocommerce",
             "version": "9.4.3",
             "source": {
@@ -3176,15 +3194,15 @@
     ],
     "minimum-stability": "stable",
     "stability-flags": {
-        "10up/elasticpress": 20,
         "10up/wp_mock": 20,
+        "10up/elasticpress": 20,
         "phpcompatibility/php-compatibility": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.0|^8.0"
+        "php": "^7.4|^8.0"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/includes/classes/Feature/CoAuthorsPlus.php
+++ b/includes/classes/Feature/CoAuthorsPlus.php
@@ -331,6 +331,9 @@ class CoAuthorsPlus extends Feature {
 	/**
 	 * Remove author weighting from the weighting configuration.
 	 *
+	 * This is necessary because the value of the author field is stored in the options,
+	 * and we need to ensure it is excluded from the weighting configuration.
+	 *
 	 * @since 2.5.0
 	 * @param array $weighting_configuration The weighting configuration.
 	 * @return array Modified weighting configuration.

--- a/includes/classes/Feature/CoAuthorsPlus.php
+++ b/includes/classes/Feature/CoAuthorsPlus.php
@@ -89,6 +89,19 @@ class CoAuthorsPlus extends Feature {
 			add_filter( 'ep_post_formatted_args', [ $this, 'include_author_in_es_query' ], 10, 3 );
 		}
 
+		/**
+		 * Filter to skip coauthor plus query integration for frontend searches.
+		 *
+		 * @since 2.5.0
+		 * @hook ep_coauthors_plus_skip_frontend_integration
+		 * @param {bool} $skip Whether to skip coauthor plus query integration. Default false.
+		 * @return {bool} Whether to skip coauthor plus query integration
+		 */
+		if ( apply_filters( 'ep_coauthors_plus_skip_frontend_integration', false ) ) {
+			add_filter( 'ep_weighting_configuration', [ $this, 'remove_author_weighting' ] );
+			return;
+		}
+
 		add_filter( 'ep_weighting_fields_for_post_type', [ $this, 'add_author_attributes_to_weighting' ], 10, 2 );
 		add_filter( 'ep_weighting_default_post_type_weights', [ $this, 'add_author_default_weight' ], 10, 2 );
 	}
@@ -313,5 +326,25 @@ class CoAuthorsPlus extends Feature {
 		];
 
 		return $defaults;
+	}
+
+	/**
+	 * Remove author weighting from the weighting configuration.
+	 *
+	 * @since 2.5.0
+	 * @param array $weighting_configuration The weighting configuration.
+	 * @return array Modified weighting configuration.
+	 */
+	public function remove_author_weighting( $weighting_configuration ) {
+		global $coauthors_plus;
+
+		$supported_post_types = $coauthors_plus->supported_post_types;
+		$author_taxonomy_key  = 'terms.' . $coauthors_plus->coauthor_taxonomy . '.name';
+
+		foreach ( $supported_post_types as $post_type ) {
+			unset( $weighting_configuration[ $post_type ][ $author_taxonomy_key ] );
+		}
+
+		return $weighting_configuration;
 	}
 }

--- a/includes/classes/Feature/CoAuthorsPlus.php
+++ b/includes/classes/Feature/CoAuthorsPlus.php
@@ -56,7 +56,7 @@ class CoAuthorsPlus extends Feature {
 
 		$this->is_protected_content_feature_active = $protected_content_feature && $protected_content_feature->is_active();
 
-		$this->requires_feature = 'protected_content';
+		$this->requires_feature = 'search';
 
 		parent::__construct();
 	}
@@ -79,15 +79,18 @@ class CoAuthorsPlus extends Feature {
 	public function setup() {
 		$settings = $this->get_settings();
 
-		if ( empty( $settings['active'] ) || ! $this->is_protected_content_feature_active ) {
+		if ( empty( $settings['active'] ) ) {
 			return;
 		}
 
 		add_filter( 'ep_sync_taxonomies', array( $this, 'include_author_term' ) );
 
-		if ( is_admin() ) {
+		if ( is_admin() && $this->is_protected_content_feature_active ) {
 			add_filter( 'ep_post_formatted_args', [ $this, 'include_author_in_es_query' ], 10, 3 );
 		}
+
+		add_filter( 'ep_weighting_fields_for_post_type', [ $this, 'add_author_attributes_to_weighting' ], 10, 2 );
+		add_filter( 'ep_weighting_default_post_type_weights', [ $this, 'add_author_default_weight' ], 10, 2 );
 	}
 
 	/**
@@ -264,5 +267,51 @@ class CoAuthorsPlus extends Feature {
 		}
 
 		return $status;
+	}
+
+	/**
+	 * Add Co-Authors attributes to the Weighting Dashboard.
+	 *
+	 * @since 2.5.0
+	 * @param array  $fields    The array of weighting fields.
+	 * @param string $post_type Current post type.
+	 * @return array Modified array of weighting fields.
+	 */
+	public function add_author_attributes_to_weighting( $fields, $post_type ) {
+		global $coauthors_plus;
+
+		if ( ! in_array( $post_type, $coauthors_plus->supported_post_types, true ) ) {
+			return $fields;
+		}
+
+		$fields['attributes']['children'][ 'terms.' . $coauthors_plus->coauthor_taxonomy . '.name' ] = [
+			'key'   => 'terms.' . $coauthors_plus->coauthor_taxonomy . '.name',
+			'label' => $coauthors_plus->guest_authors->labels['singular'],
+		];
+
+		return $fields;
+	}
+
+	/**
+	 * Add default weight for Co-Authors field.
+	 *
+	 * @since 2.5.0
+	 * @param array  $defaults  The default weight configuration.
+	 * @param string $post_type Current post type.
+	 * @return array Modified weight configuration.
+	 */
+	public function add_author_default_weight( $defaults, $post_type ) {
+		global $coauthors_plus;
+
+		if ( ! in_array( $post_type, $coauthors_plus->supported_post_types, true ) ) {
+			return $defaults;
+		}
+
+		$defaults[ 'terms.' . $coauthors_plus->coauthor_taxonomy . '.name' ] = [
+			'enabled' => true,
+			'weight'  => 1,
+		];
+
+		return $defaults;
 	}
 }

--- a/includes/classes/Feature/CoAuthorsPlus.php
+++ b/includes/classes/Feature/CoAuthorsPlus.php
@@ -242,7 +242,7 @@ class CoAuthorsPlus extends Feature {
 		$this->settings_schema = [
 			[
 				'key'   => 'instructions',
-				'label' => '<p>' . __( 'If using the Co-Authors Plus plugin and the Protected Content feature, enable this feature to visit the Admin Post List screen by Author name <code>wp-admin/edit.php?author_name=&lt;name&gt;</code> and see correct results.', 'elasticpress-labs' ) . '</p>',
+				'label' => '<p>' . __( 'When enabled, this feature integrates ElasticPress with Co-Authors Plus to enhance author-related queries on the frontend. If "Protected Content" is activated, visit the Admin Post List screen by Author name <code>wp-admin/edit.php?author_name=&lt;name&gt;</code> and see correct results.', 'elasticpress-labs' ) . '</p>',
 				'type'  => 'markup',
 			],
 		];

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -47,6 +47,7 @@ function load_plugin() {
 
 	include_once __DIR__ . '/../vendor/elasticpress/elasticpress.php';
 	include_once __DIR__ . '/../vendor/woocommerce/woocommerce.php';
+	include_once __DIR__ . '/../vendor/co-authors-plus/co-authors-plus.php';
 	include_once __DIR__ . '/../elasticpresslabs.php';
 
 	update_option( 'ep_host', $host );

--- a/tests/phpunit/feature/TestCoAuthorsPlus.php
+++ b/tests/phpunit/feature/TestCoAuthorsPlus.php
@@ -9,19 +9,22 @@
 namespace ElasticPressLabsTest;
 
 use ElasticPressLabs;
+use ElasticPress;
 
 /**
  * CoAuthors Plus test class
  *
  * @since  1.1.0
  */
-class TestCoAuthorsPlus extends \WP_UnitTestCase {
+class TestCoAuthorsPlus extends BaseTestCase {
 	/**
 	 * Setup each test.
 	 *
 	 * @since  1.1.0
 	 */
 	public function set_up() {
+		parent::set_up();
+
 		$instance = new ElasticPressLabs\Feature\CoAuthorsPlus();
 		\ElasticPress\Features::factory()->register_feature( $instance );
 	}
@@ -132,5 +135,105 @@ class TestCoAuthorsPlus extends \WP_UnitTestCase {
 		$this->assertNotEmpty( $filtered_formatted_args );
 		$this->assertCount( 1, $filtered_formatted_args );
 		$this->assertArrayHasKey( 'terms', $filtered_formatted_args[0] );
+	}
+
+	/**
+	 * Test settings schema.
+	 *
+	 * @since  2.5.0
+	 */
+	public function test_settings_schema() {
+		$expected = [
+			[
+				'default'          => false,
+				'key'              => 'active',
+				'label'            => 'Enable',
+				'requires_feature' => 'search',
+				'requires_sync'    => true,
+				'type'             => 'toggle',
+			],
+			[
+				'key'   => 'instructions',
+				'label' => '<p>If using the Co-Authors Plus plugin and the Protected Content feature, enable this feature to visit the Admin Post List screen by Author name <code>wp-admin/edit.php?author_name=&lt;name&gt;</code> and see correct results.</p>',
+				'type'  => 'markup',
+			],
+		];
+
+		$this->assertSame( $expected, $this->get_feature()->get_settings_schema() );
+	}
+
+	/**
+	 * Test attribute add in weight dashboard.
+	 *
+	 * @since  2.5.0
+	 */
+	public function test_attribute_add_in_weight_dashboard() {
+		ElasticPress\Features::factory()->activate_feature( 'co_authors_plus' );
+		ElasticPress\Features::factory()->setup_features();
+
+		$search = ElasticPress\Features::factory()->get_registered_feature( 'search' );
+		$fields = $search->weighting->get_weightable_fields_for_post_type( 'post' );
+
+		$this->assertArrayHasKey( 'terms.author.name', $fields['attributes']['children'] );
+		$this->assertEquals( 'Guest Author', $fields['attributes']['children']['terms.author.name']['label'] );
+		$this->assertEquals( 'terms.author.name', $fields['attributes']['children']['terms.author.name']['key'] );
+	}
+
+	/**
+	 * Test add author default weight.
+	 *
+	 * @since  2.5.0
+	 */
+	public function test_add_author_default_weight() {
+		ElasticPress\Features::factory()->activate_feature( 'co_authors_plus' );
+		ElasticPress\Features::factory()->setup_features();
+
+		$search = ElasticPress\Features::factory()->get_registered_feature( 'search' );
+		$fields = $search->weighting->get_post_type_default_settings( 'post' );
+
+		$this->assertArrayHasKey( 'terms.author.name', $fields );
+		$this->assertEquals( 1, $fields['terms.author.name']['weight'] );
+		$this->assertTrue( $fields['terms.author.name']['enabled'] );
+	}
+
+	/**
+	 * Test search query returns the posts if search query is a co-author.
+	 *
+	 * @since  2.5.0
+	 */
+	public function test_search_query_with_co_authors_plus() {
+		global $coauthors_plus;
+
+		ElasticPress\Features::factory()->activate_feature( 'co_authors_plus' );
+		ElasticPress\Features::factory()->setup_features();
+
+		$post_id = $this->ep_factory->post->create();
+
+		$user_login        = 'guest-author';
+		$user_display_name = 'Guest Author';
+
+		$coauthors_plus->guest_authors->create(
+			[
+				'display_name' => $user_display_name,
+				'user_login'   => $user_login,
+			]
+		);
+
+		$coauthors_plus->add_coauthors( $post_id, [ $user_login ], true, 'user_login' );
+
+		ElasticPress\Features::factory()->get_registered_feature( 'search' );
+		ElasticPress\Indexables::factory()->get( 'post' )->index( $post_id, true );
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$query = new \WP_Query(
+			[
+
+				's' => $user_display_name,
+			]
+		);
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 1, $query->found_posts );
+		$this->assertEquals( $post_id, $query->posts[0]->ID );
 	}
 }

--- a/tests/phpunit/feature/TestCoAuthorsPlus.php
+++ b/tests/phpunit/feature/TestCoAuthorsPlus.php
@@ -145,7 +145,7 @@ class TestCoAuthorsPlus extends BaseTestCase {
 	/**
 	 * Test settings schema.
 	 *
-	 * @since  2.5.0
+	 * @since 2.5.0
 	 */
 	public function test_settings_schema() {
 		$expected = [
@@ -170,7 +170,7 @@ class TestCoAuthorsPlus extends BaseTestCase {
 	/**
 	 * Test attribute add in weight dashboard.
 	 *
-	 * @since  2.5.0
+	 * @since 2.5.0
 	 */
 	public function test_attribute_add_in_weight_dashboard() {
 		ElasticPress\Features::factory()->activate_feature( 'co_authors_plus' );
@@ -187,7 +187,7 @@ class TestCoAuthorsPlus extends BaseTestCase {
 	/**
 	 * Test add author default weight.
 	 *
-	 * @since  2.5.0
+	 * @since 2.5.0
 	 */
 	public function test_add_author_default_weight() {
 		ElasticPress\Features::factory()->activate_feature( 'co_authors_plus' );
@@ -204,7 +204,7 @@ class TestCoAuthorsPlus extends BaseTestCase {
 	/**
 	 * Test search query returns the posts if search query is a co-author.
 	 *
-	 * @since  2.5.0
+	 * @since 2.5.0
 	 */
 	public function test_search_query_with_co_authors_plus() {
 		global $coauthors_plus;
@@ -245,7 +245,7 @@ class TestCoAuthorsPlus extends BaseTestCase {
 	/**
 	 * Test ep_coauthors_plus_skip_frontend_integration filter removes author weighting.
 	 *
-	 * @since  2.5.0
+	 * @since 2.5.0
 	 */
 	public function test_ep_coauthors_plus_skip_frontend_integration() {
 		add_filter( 'ep_coauthors_plus_skip_frontend_integration', '__return_true' );

--- a/tests/phpunit/feature/TestCoAuthorsPlus.php
+++ b/tests/phpunit/feature/TestCoAuthorsPlus.php
@@ -241,4 +241,21 @@ class TestCoAuthorsPlus extends BaseTestCase {
 		$this->assertEquals( 1, $query->found_posts );
 		$this->assertEquals( $post_id, $query->posts[0]->ID );
 	}
+
+	/**
+	 * Test ep_coauthors_plus_skip_frontend_integration filter removes author weighting.
+	 *
+	 * @since  2.5.0
+	 */
+	public function test_ep_coauthors_plus_skip_frontend_integration() {
+		add_filter( 'ep_coauthors_plus_skip_frontend_integration', '__return_true' );
+
+		ElasticPress\Features::factory()->activate_feature( 'co_authors_plus' );
+		ElasticPress\Features::factory()->setup_features();
+
+		$search = ElasticPress\Features::factory()->get_registered_feature( 'search' );
+		$fields = $search->weighting->get_post_type_default_settings( 'post' );
+
+		$this->assertArrayNotHasKey( 'terms.author.name', $fields );
+	}
 }

--- a/tests/phpunit/feature/TestCoAuthorsPlus.php
+++ b/tests/phpunit/feature/TestCoAuthorsPlus.php
@@ -25,6 +25,11 @@ class TestCoAuthorsPlus extends BaseTestCase {
 	public function set_up() {
 		parent::set_up();
 
+		ElasticPress\Elasticsearch::factory()->delete_all_indices();
+		ElasticPress\Indexables::factory()->get( 'post' )->put_mapping();
+
+		ElasticPress\Indexables::factory()->get( 'post' )->sync_manager->reset_sync_queue();
+
 		$instance = new ElasticPressLabs\Feature\CoAuthorsPlus();
 		\ElasticPress\Features::factory()->register_feature( $instance );
 	}

--- a/tests/phpunit/feature/TestCoAuthorsPlus.php
+++ b/tests/phpunit/feature/TestCoAuthorsPlus.php
@@ -154,7 +154,7 @@ class TestCoAuthorsPlus extends BaseTestCase {
 			],
 			[
 				'key'   => 'instructions',
-				'label' => '<p>If using the Co-Authors Plus plugin and the Protected Content feature, enable this feature to visit the Admin Post List screen by Author name <code>wp-admin/edit.php?author_name=&lt;name&gt;</code> and see correct results.</p>',
+				'label' => '<p>When enabled, this feature integrates ElasticPress with Co-Authors Plus to enhance author-related queries on the frontend. If "Protected Content" is activated, visit the Admin Post List screen by Author name <code>wp-admin/edit.php?author_name=&lt;name&gt;</code> and see correct results.</p>',
 				'type'  => 'markup',
 			],
 		];


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR adds support for searching posts by Co-Author on frontend. This PR adds a new "Guest Author" attribute in the "Search Fields & Weighting" dashboard.

<img width="831" alt="image" src="https://github.com/user-attachments/assets/f90a46d1-fd80-4bfb-8a9b-90a0a73a13e8" />


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #129 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Add a co-author to the post
2. Search the co-author on the frontend. 
3. EP should return that post. 

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Add support for searching posts by Co-Author

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
