### PR TITLE
Avoid trying to load the ElasticPressLabs more than once

### DIFF
--- a/bin/setup-cypress-env.sh
+++ b/bin/setup-cypress-env.sh
@@ -86,3 +86,4 @@ fi
 
 ./bin/wp-env-cli tests-wordpress "wp --allow-root option set posts_per_page 5"
 ./bin/wp-env-cli tests-wordpress "wp --allow-root user meta update admin edit_post_per_page 5"
+./bin/wp-env-cli tests-wordpress "wp --allow-root user update admin --user_pass=password"

--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -224,7 +224,12 @@ function maybe_load_features() {
 			continue;
 		}
 
-		$class_name = 'ElasticPressLabs\Feature\\' . basename( $filename, '.php' );
+		$basename = basename( $filename, '.php' );
+		if ( 'ElasticPressLabs' === $basename ) {
+			continue;
+		}
+
+		$class_name = 'ElasticPressLabs\Feature\\' . $basename;
 
 		if ( class_exists( $class_name ) ) {
 			$subfeature = new $class_name();


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Autoload fatal error when the plugin is installed via composer

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @burhandodhy @gsarig

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
