### PR TITLE
Check if the ES version is available before setting feature status as 2

### DIFF
--- a/includes/classes/Feature/AISearchSummary.php
+++ b/includes/classes/Feature/AISearchSummary.php
@@ -538,7 +538,8 @@ The following JSON object contains the URL and the page content. You should use 
 		$status = new \ElasticPress\FeatureRequirementsStatus( 1 );
 
 		// Vector support was added in Elasticsearch 7.0.
-		if ( version_compare( \ElasticPress\Elasticsearch::factory()->get_elasticsearch_version(), '7.0', '<' ) ) {
+		$es_version = \ElasticPress\Elasticsearch::factory()->get_elasticsearch_version();
+		if ( $es_version && version_compare( $es_version, '7.0', '<' ) ) {
 			$status->code    = 2;
 			$status->message = esc_html__( 'You need to have Elasticsearch with version >7.0.', 'elasticpress-labs' );
 		}

--- a/includes/classes/Feature/SemanticSearch/SemanticSearch.php
+++ b/includes/classes/Feature/SemanticSearch/SemanticSearch.php
@@ -67,7 +67,7 @@ class SemanticSearch extends Feature {
 		$es_version = \ElasticPress\Elasticsearch::factory()->get_elasticsearch_version();
 
 		// Vector support was added in Elasticsearch 7.0.
-		if ( version_compare( $es_version, '7.0', '<' ) ) {
+		if ( $es_version && version_compare( $es_version, '7.0', '<' ) ) {
 			$status->code    = 2;
 			$status->message = esc_html__( 'You need to have Elasticsearch with version >7.0.', 'elasticpress-labs' );
 		}

--- a/includes/classes/Feature/VectorEmbeddings/Indexable.php
+++ b/includes/classes/Feature/VectorEmbeddings/Indexable.php
@@ -43,6 +43,15 @@ abstract class Indexable {
 	public function add_vector_mapping_field( array $mapping, bool $quantization = true ): array {
 		$es_version = Elasticsearch::factory()->get_elasticsearch_version();
 
+		if ( ! isset( $mapping['mappings'], $mapping['mappings']['properties'] ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				esc_html__( 'The mapping is not valid.', 'elasticpress-labs' ),
+				'ElasticPress Labs 2.5.1'
+			);
+			return $mapping;
+		}
+
 		// Don't add the field if it already exists.
 		if ( isset( $mapping['mappings']['properties']['chunks'], $mapping['mappings']['properties']['ep_embeddings_control'] ) ) {
 			return $mapping;

--- a/includes/classes/Feature/VectorEmbeddings/VectorEmbeddings.php
+++ b/includes/classes/Feature/VectorEmbeddings/VectorEmbeddings.php
@@ -137,7 +137,8 @@ class VectorEmbeddings extends Feature {
 		$status->message = [];
 
 		// Vector support was added in Elasticsearch 7.0.
-		if ( version_compare( Elasticsearch::factory()->get_elasticsearch_version(), '7.0', '<' ) ) {
+		$es_version = Elasticsearch::factory()->get_elasticsearch_version();
+		if ( $es_version && version_compare( $es_version, '7.0', '<' ) ) {
 			$status->code      = 2;
 			$status->message[] = esc_html__( 'You need to have Elasticsearch with version >7.0.', 'elasticpress-labs' );
 			return $status;


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - AI Features being automatically disabled when ES is unavailable

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
