### PR TITLE
Fix: add vertical spacing between embedding field checkboxes

### DIFF
--- a/assets/js/embeddings/components/fieldsets/embedded-fields.js
+++ b/assets/js/embeddings/components/fieldsets/embedded-fields.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { CheckboxControl } from '@wordpress/components';
+import { CheckboxControl, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -46,26 +46,28 @@ export default ({ postType }) => {
 				)}
 			</p>
 			<Group>
-				{coreFields.map((field) => {
-					const { label, value } = field;
-					return (
-						<CheckboxControl
-							key={value}
-							label={label}
-							checked={fieldsEmbedding.includes(value)}
-							onChange={() => {
-								setEmbeddingForPostType(
-									key,
-									null,
-									'fieldsEmbedding',
-									fieldsEmbedding.includes(value)
-										? fieldsEmbedding.filter((f) => f !== value)
-										: [...fieldsEmbedding, value],
-								);
-							}}
-						/>
-					);
-				})}
+				<VStack>
+					{coreFields.map((field) => {
+						const { label, value } = field;
+						return (
+							<CheckboxControl
+								key={value}
+								label={label}
+								checked={fieldsEmbedding.includes(value)}
+								onChange={() => {
+									setEmbeddingForPostType(
+										key,
+										null,
+										'fieldsEmbedding',
+										fieldsEmbedding.includes(value)
+											? fieldsEmbedding.filter((f) => f !== value)
+											: [...fieldsEmbedding, value],
+									);
+								}}
+							/>
+						);
+					})}
+				</VStack>
 			</Group>
 			<Group>
 				<MetaSelect


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR adds vertical spacing between embedding field checkboxes.

Before:
<img width="487" height="347" alt="image" src="https://github.com/user-attachments/assets/4d97926f-e719-4488-8112-e88489c217c7" />

After:
<img width="479" height="360" alt="image" src="https://github.com/user-attachments/assets/8f727d39-85b9-4285-9723-546197004f14" />


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Add vertical spacing between embedding field checkboxes
 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
