### PR TITLE
Fix typo useVectorEmbeddingSettings

### DIFF
--- a/assets/js/embeddings/apps/settings.js
+++ b/assets/js/embeddings/apps/settings.js
@@ -8,13 +8,13 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies.
  */
-import { useVectorEmebeddingSettings } from '../provider';
+import { useVectorEmbeddingSettings } from '../provider';
 import { useSettingsScreen } from '../../settings-screen';
 import PostType from '../components/pages/post-type';
 import Indexing from '../components/pages/indexing';
 
 export default () => {
-	const { currentSettings, save } = useVectorEmebeddingSettings();
+	const { currentSettings, save } = useVectorEmbeddingSettings();
 	const { postTypeConfig: postTypes, embeddingsFiltered } = currentSettings;
 	const { createNotice } = useSettingsScreen();
 	const [currentTab, setCurrentTab] = useState(0); // eslint-disable-line

--- a/assets/js/embeddings/components/fields/meta-select.js
+++ b/assets/js/embeddings/components/fields/meta-select.js
@@ -7,11 +7,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { useVectorEmebeddingSettings } from '../../provider';
+import { useVectorEmbeddingSettings } from '../../provider';
 
 export default (props) => {
 	const { value, postType: postTypeObj, updateKey, label } = props;
-	const { setEmbeddingForPostType } = useVectorEmebeddingSettings();
+	const { setEmbeddingForPostType } = useVectorEmbeddingSettings();
 	const { key: postType } = postTypeObj;
 	return (
 		<FormTokenField

--- a/assets/js/embeddings/components/fieldsets/embedded-fields.js
+++ b/assets/js/embeddings/components/fieldsets/embedded-fields.js
@@ -10,10 +10,10 @@ import { __ } from '@wordpress/i18n';
 
 import MetaSelect from '../fields/meta-select';
 import Group from '../layout/group';
-import { useVectorEmebeddingSettings } from '../../provider';
+import { useVectorEmbeddingSettings } from '../../provider';
 
 export default ({ postType }) => {
-	const { setEmbeddingForPostType } = useVectorEmebeddingSettings();
+	const { setEmbeddingForPostType } = useVectorEmbeddingSettings();
 	const { fieldsEmbedding, key } = postType;
 
 	const coreFields = [

--- a/assets/js/embeddings/components/fieldsets/embedding-mode.js
+++ b/assets/js/embeddings/components/fieldsets/embedding-mode.js
@@ -8,11 +8,11 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Group from '../layout/group';
-import { useVectorEmebeddingSettings } from '../../provider';
+import { useVectorEmbeddingSettings } from '../../provider';
 
 export default ({ postType }) => {
 	const { embeddingMode, key } = postType;
-	const { setEmbeddingForPostType } = useVectorEmebeddingSettings();
+	const { setEmbeddingForPostType } = useVectorEmbeddingSettings();
 
 	const options = [
 		{ label: __('Manual', 'elasticpress-labs'), value: 'manual' },

--- a/assets/js/embeddings/components/fieldsets/meta-inclusion.js
+++ b/assets/js/embeddings/components/fieldsets/meta-inclusion.js
@@ -9,11 +9,11 @@ import { CheckboxControl } from '@wordpress/components';
  */
 import MetaSelect from '../fields/meta-select';
 import Group from '../layout/group';
-import { useVectorEmebeddingSettings } from '../../provider';
+import { useVectorEmbeddingSettings } from '../../provider';
 
 export default ({ postType, embeddingMode }) => {
 	const { fieldsIndexingInclude, fieldsIndexingExclude, enablefieldsIndexing, key } = postType;
-	const { setEmbeddingForPostType } = useVectorEmebeddingSettings();
+	const { setEmbeddingForPostType } = useVectorEmbeddingSettings();
 	return (
 		<>
 			<h4>{__('Post Meta', 'elasticpress-labs')}</h4>

--- a/assets/js/embeddings/components/fieldsets/taxonomy-inclusion.js
+++ b/assets/js/embeddings/components/fieldsets/taxonomy-inclusion.js
@@ -7,12 +7,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies.
  */
-import { useVectorEmebeddingSettings } from '../../provider';
+import { useVectorEmbeddingSettings } from '../../provider';
 import TermSelect from '../fields/term-select';
 import Group from '../layout/group';
 
 export default ({ taxonomies, postType }) => {
-	const { setEmbeddingForPostType } = useVectorEmebeddingSettings();
+	const { setEmbeddingForPostType } = useVectorEmbeddingSettings();
 	const hasTaxonomies = Object.keys(taxonomies).length > 0;
 	const { key } = postType;
 

--- a/assets/js/embeddings/components/pages/indexing.js
+++ b/assets/js/embeddings/components/pages/indexing.js
@@ -7,10 +7,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { useVectorEmebeddingSettings } from '../../provider';
+import { useVectorEmbeddingSettings } from '../../provider';
 
 export default () => {
-	const { currentSettings, setChunkSize, setChunkOverlap } = useVectorEmebeddingSettings();
+	const { currentSettings, setChunkSize, setChunkOverlap } = useVectorEmbeddingSettings();
 	const { chunkSize, chunkOverlap } = currentSettings;
 	return (
 		<Panel>

--- a/assets/js/embeddings/components/pages/post-type.js
+++ b/assets/js/embeddings/components/pages/post-type.js
@@ -7,14 +7,14 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { useVectorEmebeddingSettings } from '../../provider';
+import { useVectorEmbeddingSettings } from '../../provider';
 import TaxonomyInclusion from '../fieldsets/taxonomy-inclusion';
 import MetaInclusion from '../fieldsets/meta-inclusion';
 import EmbeddedFields from '../fieldsets/embedded-fields';
 import EmbeddingMode from '../fieldsets/embedding-mode';
 
 export default ({ postType }) => {
-	const { setEmbeddingForPostType } = useVectorEmebeddingSettings();
+	const { setEmbeddingForPostType } = useVectorEmbeddingSettings();
 	const {
 		embeddable,
 		fieldsIndexingInclude,

--- a/assets/js/embeddings/provider.js
+++ b/assets/js/embeddings/provider.js
@@ -139,6 +139,6 @@ export const VectorEmbeddingsProvider = ({
  *
  * @returns {object} API Search Context.
  */
-export const useVectorEmebeddingSettings = () => {
+export const useVectorEmbeddingSettings = () => {
 	return useContext(Context);
 };


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the typo in the useVectorEmbeddingSettings

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Typo fix useVectorEmbeddingSettings
 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
