### PR TITLE
Fix: deprecated warning and wrap checkboxes in VStack component

### DIFF
--- a/assets/js/embeddings/components/fieldsets/meta-inclusion.js
+++ b/assets/js/embeddings/components/fieldsets/meta-inclusion.js
@@ -12,24 +12,24 @@ import Group from '../layout/group';
 import { useVectorEmbeddingSettings } from '../../provider';
 
 export default ({ postType, embeddingMode }) => {
-	const { fieldsIndexingInclude, fieldsIndexingExclude, enablefieldsIndexing, key } = postType;
+	const { fieldsIndexingInclude, fieldsIndexingExclude, enableFieldsIndexing, key } = postType;
 	const { setEmbeddingForPostType } = useVectorEmbeddingSettings();
 	return (
 		<>
 			<h4>{__('Post Meta', 'elasticpress-labs')}</h4>
 			<CheckboxControl
 				label={__('Post Meta Fields', 'elasticpress-labs')}
-				checked={enablefieldsIndexing}
+				checked={enableFieldsIndexing}
 				onChange={() => {
 					setEmbeddingForPostType(
 						key,
 						null,
-						'enablefieldsIndexing',
-						!enablefieldsIndexing,
+						'enableFieldsIndexing',
+						!enableFieldsIndexing,
 					);
 				}}
 			/>
-			{embeddingMode === 'automatic' && enablefieldsIndexing && (
+			{embeddingMode === 'automatic' && enableFieldsIndexing && (
 				<>
 					<Group indent>
 						<MetaSelect

--- a/assets/js/embeddings/components/fieldsets/taxonomy-inclusion.js
+++ b/assets/js/embeddings/components/fieldsets/taxonomy-inclusion.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  * */
-import { CheckboxControl } from '@wordpress/components';
+import { CheckboxControl, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -20,62 +20,64 @@ export default ({ taxonomies, postType }) => {
 		<div>
 			<h4>{__('Taxonomies', 'elasticpress-labs')}</h4>
 			{hasTaxonomies > 0 ? (
-				Object.keys(taxonomies).map((taxonomy) => {
-					const { label, termsInclude, termsExclude, enabled } = taxonomies[taxonomy];
-					return (
-						<>
-							<CheckboxControl
-								label={label}
-								checked={enabled}
-								onChange={() => {
-									setEmbeddingForPostType(key, taxonomy, 'enabled', !enabled);
-								}}
-							/>
-							{enabled && (
-								<>
-									<Group indent>
-										<TermSelect
-											postType={postType}
-											taxonomy={taxonomy}
-											label={__(
-												'Include posts that have any of these terms',
-												'elasticpress-labs',
-											)}
-											value={termsInclude}
-											onChange={(terms) =>
-												setEmbeddingForPostType(
-													key,
-													taxonomy,
-													'termsInclude',
-													terms,
-												)
-											}
-										/>
-									</Group>
-									<Group indent>
-										<TermSelect
-											postType={postType}
-											taxonomy={taxonomy}
-											label={__(
-												'Exclude posts that have any of these terms',
-												'elasticpress-labs',
-											)}
-											onChange={(terms) =>
-												setEmbeddingForPostType(
-													key,
-													taxonomy,
-													'termsExclude',
-													terms,
-												)
-											}
-											value={termsExclude}
-										/>
-									</Group>
-								</>
-							)}
-						</>
-					);
-				})
+				<VStack>
+					{Object.keys(taxonomies).map((taxonomy) => {
+						const { label, termsInclude, termsExclude, enabled } = taxonomies[taxonomy];
+						return (
+							<>
+								<CheckboxControl
+									label={label}
+									checked={enabled}
+									onChange={() => {
+										setEmbeddingForPostType(key, taxonomy, 'enabled', !enabled);
+									}}
+								/>
+								{enabled && (
+									<>
+										<Group indent>
+											<TermSelect
+												postType={postType}
+												taxonomy={taxonomy}
+												label={__(
+													'Include posts that have any of these terms',
+													'elasticpress-labs',
+												)}
+												value={termsInclude}
+												onChange={(terms) =>
+													setEmbeddingForPostType(
+														key,
+														taxonomy,
+														'termsInclude',
+														terms,
+													)
+												}
+											/>
+										</Group>
+										<Group indent>
+											<TermSelect
+												postType={postType}
+												taxonomy={taxonomy}
+												label={__(
+													'Exclude posts that have any of these terms',
+													'elasticpress-labs',
+												)}
+												onChange={(terms) =>
+													setEmbeddingForPostType(
+														key,
+														taxonomy,
+														'termsExclude',
+														terms,
+													)
+												}
+												value={termsExclude}
+											/>
+										</Group>
+									</>
+								)}
+							</>
+						);
+					})}
+				</VStack>
 			) : (
 				<p>
 					{__(

--- a/assets/js/embeddings/components/pages/indexing.js
+++ b/assets/js/embeddings/components/pages/indexing.js
@@ -24,6 +24,7 @@ export default () => {
 					onChange={setChunkSize}
 					min={1}
 					max={300}
+					__next40pxDefaultSize
 				/>
 				<RangeControl
 					label={__('Chunk Overlap (in words)', 'elasticpress-labs')}
@@ -31,6 +32,7 @@ export default () => {
 					onChange={setChunkOverlap}
 					min={1}
 					max={100}
+					__next40pxDefaultSize
 				/>
 			</PanelBody>
 		</Panel>

--- a/includes/classes/Feature/VectorEmbeddings/Settings.php
+++ b/includes/classes/Feature/VectorEmbeddings/Settings.php
@@ -202,7 +202,7 @@ class Settings {
 			$return[] = [
 				'embeddable'            => true, // whether to allow embeddings for this post type.
 				'embeddingMode'         => 'automatic', // Whether to use auto or manual embedding.
-				'enablefieldsIndexing'  => false, // Whether to flagging content inclusion via post meta.
+				'enableFieldsIndexing'  => false, // Whether to flagging content inclusion via post meta.
 				'fieldsIndexingInclude' => [], // Meta fields used to flag content for inclusion.
 				'fieldsIndexingExclude' => [], // Meta fields used to flag content for exclusion. A post with an exluded
 				'fieldsEmbedding'       => [ 'post_title', 'post_content' ], // Fields to use for embedding generation.


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the following issues. 

1. Fix: 36px default size for wp.components.RangeControl is deprecated since version 6.8 and will be removed in version 7.1
2. Wrap Checkboxes in `VStack` component.
3. Renames `enablefieldsIndexing` to `enableFieldsIndexing`.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - 36px default size for wp.components.RangeControl is deprecated since 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
